### PR TITLE
Adding util-linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.util-linux?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=141&branchName=master)
+
+# util-linux
+
+Miscellaneous system utilities for Linux
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "util-linux"

--- a/controls/util_linux_test.rb
+++ b/controls/util_linux_test.rb
@@ -1,0 +1,98 @@
+title 'Tests to confirm util-linux works as expected'
+
+plan_name = input('plan_name', value: 'util-linux')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-util-linux' do
+  impact 1.0
+  title 'Ensure util-linux works'
+  desc '
+  util-linux contains a large number of binary executables.  We perform basic operations with
+  several of these to ensure the package is working correctly.
+
+    $ uuidgen --sha1 --namespace @dns --name "www.example.com"
+    2ed6657d-e927-568b-95e1-2665a8aea6a2
+
+    $ whereis uuidgen
+    uuidgen: /hab/pkgs/core/util-linux/2.34/20200306003119/bin/uuidgen
+
+    $ look --version
+    look from util-linux 2.34
+
+    $ cal -y
+                                   2020
+
+           January               February                 March
+    Su Mo Tu We Th Fr Sa   Su Mo Tu We Th Fr Sa   Su Mo Tu We Th Fr Sa
+              1  2  3  4                      1    1  2  3  4  5  6  7
+     5  6  7  8  9 10 11    2  3  4  5  6  7  8    8  9 10 11 12 13 14
+    12 13 14 15 16 17 18    9 10 11 12 13 14 15   15 16 17 18 19 20 21
+    19 20 21 22 23 24 25   16 17 18 19 20 21 22   22 23 24 25 26 27 28
+    26 27 28 29 30 31      23 24 25 26 27 28 29   29 30 31
+    ...
+
+    $ lscpu
+    Architecture:                    x86_64
+    CPU op-mode(s):                  32-bit, 64-bit
+    Byte Order:                      Little Endian
+    Address sizes:                   39 bits physical, 48 bits virtual
+    CPU(s):                          4
+    ...
+
+    $ lsmem
+    RANGE                                  SIZE  STATE REMOVABLE BLOCK
+    0x0000000000000000-0x000000009fffffff  2.5G online        no  0-19
+    0x00000000a0000000-0x00000000b7ffffff  384M online       yes 20-22
+    ...
+  '
+  util_linux_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  describe util_linux_pkg_ident do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  util_linux_pkg_ident = util_linux_pkg_ident.stdout.strip
+
+  describe command("#{util_linux_pkg_ident}/bin/whereis uuidgen") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /bin\/uuidgen/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{util_linux_pkg_ident}/bin/uuidgen --sha1 --namespace @dns --name 'www.example.com'") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /2ed6657d-e927-568b-95e1-2665a8aea6a2/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{util_linux_pkg_ident}/bin/look --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /look from util-linux #{util_linux_pkg_ident.split('/')[5]}/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{util_linux_pkg_ident}/bin/cal -y") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /August/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{util_linux_pkg_ident}/bin/lscpu") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /CPU/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{util_linux_pkg_ident}/bin/lsmem") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Memory block size/ }
+    its('stderr') { should be_empty }
+  end
+end
+

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: util-linux
+title: Habitat Core Plan util-linux
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan util-linux
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,69 @@
+pkg_name=util-linux
+pkg_origin=core
+pkg_version=2.34
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Miscellaneous system utilities for Linux"
+pkg_upstream_url="https://www.kernel.org/pub/linux/utils/util-linux"
+pkg_license=('GPLv2-or-later')
+pkg_source="https://www.kernel.org/pub/linux/utils/${pkg_name}/v${pkg_version%.?}/${pkg_name}-${pkg_version}.tar.xz"
+pkg_shasum="743f9d0c7252b6db246b659c1e1ce0bd45d8d4508b4dfa427bbb4a3e9b9f62b5"
+pkg_deps=(
+  core/glibc
+  core/zlib
+  core/ncurses
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/sed
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_build() {
+  ./configure \
+    --prefix="$pkg_prefix" \
+    --sbindir="$pkg_prefix/bin" \
+    --localstatedir="$pkg_svc_var_path/run" \
+    --without-python \
+    --without-slang \
+    --without-systemd \
+    --without-systemdsystemunitdir \
+    --disable-use-tty-group \
+    --disable-chfn-chsh \
+    --disable-login \
+    --disable-nologin \
+    --disable-su \
+    --disable-setpriv \
+    --disable-runuser \
+    --disable-pylibmount
+  make
+}
+
+do_install() {
+  make install usrsbin_execdir="$pkg_prefix/bin"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+    core/sed
+    core/diffutils
+    core/make
+    core/patch
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,5 @@
+@test "uuidgen produces known output" {
+  run hab pkg exec $TEST_PKG_IDENT uuidgen --sha1 --namespace @dns --name "www.example.com"
+  [ "$output" == "2ed6657d-e927-568b-95e1-2665a8aea6a2" ]
+}
+

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
Migration from core plans adding InSpec tests:

```
Profile: Habitat Core Plan util-linux (util-linux)
Version: 0.1.0
Target:  docker://da1bb4cafa09e36c65c80c7e9fc2c3c809c8c71a45c58a7cc92325138eb870b1

  ✔  core-plans-util-linux: Ensure util-linux works
     ✔  Command: `hab pkg path habskp/util-linux` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/util-linux` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/whereis uuidgen` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/whereis uuidgen` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/whereis uuidgen` stdout is expected to match /bin\/uuidgen/
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/whereis uuidgen` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/uuidgen --sha1 --namespace @dns --name 'www.example.com'` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/uuidgen --sha1 --namespace @dns --name 'www.example.com'` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/uuidgen --sha1 --namespace @dns --name 'www.example.com'` stdout is expected to match /2ed6657d-e927-568b-95e1-2665a8aea6a2/
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/uuidgen --sha1 --namespace @dns --name 'www.example.com'` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/look --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/look --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/look --version` stdout is expected to match /look from util-linux 2.34/
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/look --version` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/cal -y` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/cal -y` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/cal -y` stdout is expected to match /August/
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/cal -y` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/lscpu` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/lscpu` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/lscpu` stdout is expected to match /CPU/
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/lscpu` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/lsmem` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/lsmem` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/lsmem` stdout is expected to match /Memory block size/
     ✔  Command: `/hab/pkgs/habskp/util-linux/2.34/20200612104936/bin/lsmem` stderr is expected to be empty


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 26 successful, 0 failures, 0 skipped
```

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
